### PR TITLE
Point to `.d.mts` types instead of `.d.ts` files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/parse-ingredient.d.ts",
+      "types": "./dist/parse-ingredient.d.mts",
       "import": "./dist/parse-ingredient.mjs",
       "require": "./dist/cjs/index.js"
     }
   },
-  "types": "./dist/parse-ingredient.d.ts",
+  "types": "./dist/parse-ingredient.d.mts",
   "unpkg": "./dist/parse-ingredient.umd.min.js",
   "keywords": [
     "parse",


### PR DESCRIPTION
When installed to a project on my machine, the files in `dist` only contain a `.d.mts` and not the `.d.ts` that `package.json` points to.

![image](https://github.com/jakeboone02/parse-ingredient/assets/9111807/afa37d8d-4959-4730-8eb5-00b1ff666ba0)

Currently, my IDE doesn't recognize `parse-ingredient` as having types. Making this change locally fixed the issue for me. I'm not sure if this issue has any me-specific component that I'm missing, but if not it looks like an easy fix.