### PR TITLE
Convert ingredient quantities with commas as decimals to decimal points

### DIFF
--- a/src/parseIngredient.ts
+++ b/src/parseIngredient.ts
@@ -39,6 +39,9 @@ export const parseIngredient = (
     .filter(Boolean);
 
   return ingredientArray.map(line => {
+    // Normalize comma decimals to dot decimals (Ex. "1,5" to "1.5")
+    line = line.replace(/(\d),(?!\d{3}(?!\d))(\d+)/g, '$1.$2');
+
     const oIng: Ingredient = {
       quantity: null,
       quantity2: null,

--- a/src/parseIngredientTests.ts
+++ b/src/parseIngredientTests.ts
@@ -403,6 +403,19 @@ export const parseIngredientTests: Record<
       },
     ],
   ],
+  'comma decimal to decimal point': [
+    '1,2 kg pork loin',
+    [
+      {
+        "quantity": 1.2,
+        "quantity2": null,
+        "unitOfMeasureID": "kilogram",
+        "unitOfMeasure": "kg",
+        "description": "pork loin",
+        "isGroupHeader": false
+      }
+    ],
+  ],
   ...Object.fromEntries(
     [
       ['basic', ''],


### PR DESCRIPTION
I need to be able to support recipes where they write decimal places with commas instead of decimal points. They're typically written this way in Europe and other places.

This change converts those units to decimal points, then handles things as normal. It will also avoid converting thousands separators like "1,000"